### PR TITLE
Add Specify

### DIFF
--- a/src/data.tsx
+++ b/src/data.tsx
@@ -154,6 +154,10 @@ export const features: Feature[] = [
         link: 'https://www.taskade.com/templates/design/the-ultimate-design-system-checklist',
       },
       {
+        title: 'Specify',
+        link: 'https://specifyapp.com',
+      },
+      {
         title: 'Figma Tokens',
         link: 'https://jansix.at/resources/figma-tokens',
       },


### PR DESCRIPTION
Add Specify in the list of tools helping people sync and transform their design tokens.